### PR TITLE
Handle missing Supabase admin credentials for Spotify routes

### DIFF
--- a/ezra-birthday-dashboard/lib/supabase/admin.ts
+++ b/ezra-birthday-dashboard/lib/supabase/admin.ts
@@ -2,12 +2,42 @@ import { createClient } from '@supabase/supabase-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from './server';
 
+export class MissingSupabaseAdminCredentialsError extends Error {
+  public readonly missingEnvVars: string[];
+
+  constructor(missingEnvVars: string[]) {
+    super(
+      `Missing Supabase admin environment variables: ${missingEnvVars.join(
+        ', '
+      )}. Please configure NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY.`
+    );
+    this.name = 'MissingSupabaseAdminCredentialsError';
+    this.missingEnvVars = missingEnvVars;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MissingSupabaseAdminCredentialsError);
+    }
+  }
+}
+
 export const createAdminSupabaseClient = <T extends Database = Database>() => {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceKey = process.env.SUPABASE_SERVICE_KEY;
 
-  if (!supabaseUrl || !serviceKey) {
-    throw new Error('Missing Supabase admin environment variables. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY.');
+  const missingEnvVars: string[] = [];
+  if (!supabaseUrl) {
+    missingEnvVars.push('NEXT_PUBLIC_SUPABASE_URL');
+  }
+  if (!serviceKey) {
+    missingEnvVars.push('SUPABASE_SERVICE_KEY');
+  }
+
+  if (missingEnvVars.length > 0) {
+    console.error(
+      '[Supabase] Missing admin credentials. Please set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_KEY before running the server.',
+      { missingEnvVars }
+    );
+    throw new MissingSupabaseAdminCredentialsError(missingEnvVars);
   }
 
   return createClient<T>(supabaseUrl, serviceKey, {


### PR DESCRIPTION
## Summary
- add a Supabase admin helper that logs missing credentials and throws a typed error when the service URL or key are absent
- update the Spotify status and callback handlers to catch the custom error and return informative responses instead of crashing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ce6d89dd7c8321b84f2bf025e54120